### PR TITLE
Remove double scroll in tablet view

### DIFF
--- a/src/app/pages/tradtondoc/tradtondoc.component.scss
+++ b/src/app/pages/tradtondoc/tradtondoc.component.scss
@@ -70,7 +70,7 @@
         }
         @media screen and (orientation: portrait) {
           .cropper {
-            max-height: 530px;
+            max-height: 100%;
           }
         }
         .text-area {


### PR DESCRIPTION
Just set the max-height to 100% so the cropper display the whole image instead of just a little part of it